### PR TITLE
[front] 상품 상점 리스트 조회 API

### DIFF
--- a/core/src/main/kotlin/com/sp/domain/product/entity/Product.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/Product.kt
@@ -5,23 +5,21 @@ import javax.persistence.*
 
 @Entity
 @Table( name = "product" )
-class Product (name: String, price: Int){
+class Product (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "product_no")
-    var no: Long = 0
+    var no: Long = 0,
 
     @Column(name="parent_no")
-    var parentNo: Long? = null
+    var parentNo: Long? = null,
 
     @Column(name = "name")
-    var name: String = name
+    var name: String,
 
     @Column(name = "price")
-    var price: Int = price
-
-    @OneToMany(mappedBy = "product")
-    var storeProduct: List<StoreProduct>? = null
+    var price: Int
+        ) {
 
     companion object{
         fun create(param: ProductRegisterModel) = Product(
@@ -29,5 +27,4 @@ class Product (name: String, price: Int){
             price = param.price
         )
     }
-
 }

--- a/core/src/main/kotlin/com/sp/domain/product/entity/Store.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/Store.kt
@@ -17,9 +17,6 @@ class Store (name: String, address: String){
     @Column(name= "address")
     var address: String = address
 
-    @OneToMany(mappedBy = "store")
-    var storeProduct: List<StoreProduct>? = null
-
     companion object {
         fun create(param: StoreRegisterModel) = Store(
             name = param.name,

--- a/core/src/main/kotlin/com/sp/domain/product/entity/StoreProduct.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/StoreProduct.kt
@@ -1,35 +1,40 @@
 package com.sp.domain.product.entity
 
-import java.util.*
+import com.sp.domain.product.entity.model.StoreProductRegisterModel
+import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
 @Table(name = "store_product")
-class StoreProduct (product: Product, store: Store){
-
+class StoreProduct (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "store_product_no")
-    var storeProductNo: Long? = null
+    var storeProductNo: Long? = null,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    var product: Product = product
+    @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_no")
+    var product: Product,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    var store: Store = store
+    @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @JoinColumn(name="store_no")
+    var store: Store,
 
     @Column(name = "reg_date")
-    var regDate: Date? = null
+    var regDate: LocalDateTime? = LocalDateTime.now(),
 
     @Column(name = "mod_date")
-    var modDate: Date? = null
+    var modDate: LocalDateTime? = LocalDateTime.now(),
 
+    @Column(name = "count")
+    var count: Int? = 0
+
+    ){
     companion object{
-        fun create(product:Product, store: Store) = StoreProduct(
-            product = product,
-            store = store
+        fun create(params: StoreProductRegisterModel) = StoreProduct(
+            product = Product.create(params.product),
+            store = Store.create(params.store),
+            count = params.count
         )
     }
 }

--- a/front/src/main/kotlin/com/sp/application/ProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/ProductService.kt
@@ -1,27 +1,16 @@
 package com.sp.application
 
-import com.sp.domain.ProductDomainService
+import com.sp.domain.product.ProductDomainService
 import com.sp.domain.product.entity.Product
 import com.sp.presentation.request.ProductRegisterRequest
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 
 @Service
-@Transactional(readOnly = true)
 class ProductService(
     private val productDomainService: ProductDomainService
 ) {
-    @Transactional
-    suspend fun findAllProducts():List<Product> {
-        return productDomainService.findAllProducts()
-    }
-
-    suspend fun findById(id: Long): Optional<Product> {
-        return productDomainService.findById(id)
-    }
-
     suspend fun registerProduct(params: ProductRegisterRequest): Long {
         return productDomainService.register(params)
     }

--- a/front/src/main/kotlin/com/sp/application/StoreProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/StoreProductService.kt
@@ -1,0 +1,12 @@
+package com.sp.application
+
+import com.sp.domain.product.entity.StoreProduct
+import com.sp.domain.storeProduct.StoreProductRepositoryImpl
+import org.springframework.stereotype.Service
+
+@Service
+class StoreProductService(private val spRepository: StoreProductRepositoryImpl) {
+    suspend fun getStoreList(name: String): List<StoreProduct> {
+        return spRepository.getStoreList(name, 2L)
+    }
+}

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProducRespository.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProducRespository.kt
@@ -1,0 +1,7 @@
+package com.sp.domain.storeProduct
+
+import com.sp.domain.product.entity.StoreProduct
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
+
+interface StoreProducRespository: JpaRepository<StoreProduct, Long>, QuerydslPredicateExecutor<StoreProduct>

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImpl.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.sp.domain.storeProduct
+
+import com.querydsl.core.types.Predicate
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sp.domain.product.entity.QProduct.product
+import com.sp.domain.product.entity.QStoreProduct
+import com.sp.domain.product.entity.StoreProduct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+import javax.annotation.Resource
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Repository
+class StoreProductRepositoryImpl(
+    @Autowired
+    @Resource(name = "jpaQueryFactory")
+    var query : JPAQueryFactory
+    ): QuerydslRepositorySupport(StoreProduct::class.java) {
+
+    val storeProduct = QStoreProduct.storeProduct
+
+    fun getStoreList(name: String, pageSize: Long) :List<StoreProduct> {
+        return query
+            .select(storeProduct)
+            .from(storeProduct)
+            .where(storeProduct.product.name.containsIgnoreCase(name))
+            .limit(pageSize)
+            .fetch()
+    }
+}

--- a/front/src/main/kotlin/com/sp/infrastructure/queryDslConfig.kt
+++ b/front/src/main/kotlin/com/sp/infrastructure/queryDslConfig.kt
@@ -1,0 +1,19 @@
+package com.sp.infrastructure
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+
+@Configuration
+class queryDslConfig {
+    @PersistenceContext
+    private val entityManager: EntityManager? = null
+
+    @Bean
+    open fun jpaQueryFactory(): JPAQueryFactory? {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/front/src/main/kotlin/com/sp/presentation/handler/ProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/ProductHandler.kt
@@ -1,7 +1,6 @@
 package com.sp.presentation.handler
 
 import com.sp.application.ProductService
-import com.sp.domain.ProductRepository
 import com.sp.presentation.request.ProductRegisterRequest
 import org.springframework.stereotype.*
 import org.springframework.web.reactive.function.server.*
@@ -12,12 +11,6 @@ import java.net.URI
 class ProductHandler (
     private val productService: ProductService
 ) {
-    suspend fun findAll(request: ServerRequest): ServerResponse =
-        ServerResponse.ok().json().bodyValueAndAwait(productService.findAllProducts())
-
-    suspend fun findById(request: ServerRequest): ServerResponse =
-            ServerResponse.ok().json().bodyValueAndAwait(productService.findById(request.pathVariable("id").toLong()))
-
     suspend fun register(request: ServerRequest): ServerResponse {
         val params = request.awaitBody<ProductRegisterRequest>()
         val memberNo = productService.registerProduct(params)

--- a/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
@@ -1,0 +1,16 @@
+package com.sp.presentation.handler
+
+import com.sp.application.StoreProductService
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.json
+
+@Component
+class StoreProductHandler(
+    private val storeProductService: StoreProductService
+) {
+    suspend fun getStoreList(request: ServerRequest): ServerResponse =
+        ServerResponse.ok().json().bodyValueAndAwait(storeProductService.getStoreList(request.pathVariable("name")))
+}

--- a/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
+++ b/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
@@ -1,31 +1,25 @@
 package com.sp.presentation.router
 
 import com.sp.presentation.handler.ProductHandler
+import com.sp.presentation.handler.StoreProductHandler
 import org.springframework.context.annotation.*
 import org.springframework.http.*
 import org.springframework.web.reactive.function.server.*
 import reactor.core.publisher.Mono
 
 @Configuration
-class ProductRouter(private val productHandler: ProductHandler) {
+class ProductRouter(
+    private val productHandler: ProductHandler,
+    private val storeProductHandler: StoreProductHandler
+) {
 
     @Bean
     fun routeProductGet(): RouterFunction<ServerResponse> {
         return coRouter {
             ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
                 accept(MediaType.APPLICATION_JSON).nest {
-                    GET("", productHandler::findAll)
-                }
-            }
-        }
-    }
-
-    @Bean
-    fun routeProductPost(): RouterFunction<ServerResponse> {
-        return coRouter {
-            ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
-                accept(MediaType.APPLICATION_JSON).nest {
                     POST("", productHandler::register)
+                    GET("/{name}", storeProductHandler::getStoreList)
                 }
             }
         }

--- a/front/src/test/kotlin/com/sp/application/StoreProductServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/StoreProductServiceTest.kt
@@ -1,0 +1,39 @@
+package com.sp.application
+
+import com.sp.domain.product.ProductDomainService
+import com.sp.domain.storeProduct.StoreProductRepositoryImpl
+import com.sp.presentation.request.ProductRegisterRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class StoreProductServiceTest {
+    @MockK
+    private lateinit var storeProductRepositoryImpl: StoreProductRepositoryImpl
+
+    private lateinit var storeProductService: StoreProductService
+
+    @BeforeEach
+    fun setUp(){
+        storeProductService = StoreProductService(storeProductRepositoryImpl)
+    }
+
+    @Test
+    fun `상품명으로 상점 리스트 조회`(){
+        //given
+
+        //when
+        coEvery { storeProductRepositoryImpl.getStoreList(any(), 1L) } returns listOf()
+        runBlocking { storeProductService.getStoreList("koko") }
+
+        //then
+        coVerify { storeProductService.getStoreList("koko") }
+    }
+}

--- a/front/src/test/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImplTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImplTest.kt
@@ -1,0 +1,49 @@
+package com.sp.domain.storeProduct
+
+import com.ninjasquad.springmockk.MockkBean
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sp.application.StoreProductService
+import com.sp.domain.extensions.toJson
+import com.sp.domain.product.entity.QStoreProduct
+import com.sp.infrastructure.queryDslConfig
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.stereotype.Repository
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
+import javax.annotation.Resource
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ComponentScan(useDefaultFilters = false, includeFilters = [ComponentScan.Filter(Repository::class)])
+@Import(queryDslConfig::class)
+class StoreProductRepositoryImplTest{
+    private lateinit var spRepositoryImpl: StoreProductRepositoryImpl
+
+    @Autowired
+    @Resource(name = "jpaQueryFactory")
+    lateinit var query : JPAQueryFactory
+
+    @BeforeEach
+    fun setUp(){
+        spRepositoryImpl = StoreProductRepositoryImpl(query)
+    }
+    @Test
+    fun `상품명으로 상점 리스트 조회`(){
+        //when
+        val storeList = spRepositoryImpl.getStoreList("koko", 1L)
+
+        //then
+        Assertions.assertEquals(storeList.get(0).store.name, "GS25")
+        Assertions.assertEquals(storeList.get(0).store.address, "고척1동")
+    }
+}

--- a/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
@@ -1,0 +1,57 @@
+package com.sp.presentation.handler
+
+import com.sp.application.StoreProductService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.reactive.function.server.HandlerStrategies
+import org.springframework.web.reactive.function.server.ServerRequest
+
+@ExtendWith(MockKExtension::class)
+internal class StoreProductHandlerTest{
+    @MockK
+    private lateinit var storeProductService: StoreProductService
+
+    private lateinit var storeProductHandler: StoreProductHandler
+
+    @BeforeEach
+    internal fun setUp(){
+        storeProductHandler = StoreProductHandler(storeProductService)
+    }
+
+    @AfterEach
+    internal fun after(){
+        unmockkAll()
+    }
+
+    @Test
+    fun `상품명으로 상점 리스트 조회`(){
+        val request = MockServerHttpRequest
+            .get("/backend/product/koko")
+
+        val exchange = MockServerWebExchange
+            .from(request)
+            .let{ ServerRequest.create(it, HandlerStrategies.withDefaults().messageReaders())}
+
+        coEvery { storeProductService.getStoreList(any()) } returns listOf()
+
+        //when
+        val response = runBlocking { storeProductHandler.getStoreList(exchange) }
+
+        //then
+        assertEquals(HttpStatus.CREATED, response.statusCode())
+
+        coVerify { storeProductService.getStoreList(any()) }
+    }
+}

--- a/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
@@ -3,10 +3,11 @@ package com.sp.presentation.router
 import com.ninjasquad.springmockk.*
 import com.sp.application.*
 import com.sp.domain.product.entity.Product
+import com.sp.domain.product.entity.StoreProduct
 import com.sp.presentation.handler.ProductHandler
+import com.sp.presentation.handler.StoreProductHandler
 import com.sp.presentation.request.ProductRegisterRequest
 import io.mockk.coEvery
-import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -22,12 +23,15 @@ import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest
 @ExtendWith(RestDocumentationExtension::class)
-@ContextConfiguration(classes = [ProductRouter::class, ProductHandler::class])
+@ContextConfiguration(classes = [ProductRouter::class, ProductHandler::class, StoreProductHandler::class])
 internal class ProductRouterTest(private val context: ApplicationContext){
     private lateinit var webTestClient: WebTestClient
 
     @MockkBean
     private lateinit var productService: ProductService
+
+    @MockkBean
+    private lateinit var storeProductService: StoreProductService
 
     @BeforeEach
     fun setup(restDocumentation: RestDocumentationContextProvider) {
@@ -37,24 +41,6 @@ internal class ProductRouterTest(private val context: ApplicationContext){
             .filter(WebTestClientRestDocumentation.documentationConfiguration(restDocumentation))
             .build()
     }
-
-    @Test
-    fun `상품 전체 조회`() {
-        val product = Product(
-            name = "꼬북칩",
-            price = 1500
-        )
-        coEvery { productService.findAllProducts() } returns listOf(product)
-        
-        webTestClient.get()
-            .uri("/backend/product")
-            .header("Version", "1.0")
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus().isOk
-    }
-
     @Test
     fun `부모 상품 등록`() {
         val request = ProductRegisterRequest(
@@ -72,5 +58,20 @@ internal class ProductRouterTest(private val context: ApplicationContext){
             .bodyValue(request)
             .exchange()
             .expectStatus().isCreated
+    }
+
+    @Test
+    fun `상품명으로 상점 리스트 조회`() {
+        val productName = "koko"
+
+        coEvery { storeProductService.getStoreList(any()) } returns listOf()
+
+        webTestClient.get()
+            .uri("/backend/product/"+productName)
+            .header("Version", "1.0")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isOk
     }
 }


### PR DESCRIPTION
 상품명으로 등록되어 있는 상점위치 조회
- StoreProduct에서 상품명을 이용해 상점 정보와 상품개수 등의 정보를 리스트로 호출
- 기존에 Product 에서 StoreProduct 조회 하려고 하던것을 StoreProduct에서 Product와 Store 조회 할수 있도록 변경
- Product 엔티티와 Store 엔티티에서는 StoreProduct의 정보 조회할수 없도록 StoreProduct 단방향 조회로 변경
- QueryDsl 적용
- 부족한거 막 지적해주기 (테스트코드작성이 어렵다..help)