### PR TITLE
상품 관련 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,11 @@ val springRestdocsVersion: String by extra { "2.0.4.RELEASE" }
 
 buildscript {
 	repositories {
-		repositories { mavenCentral() }
+		mavenCentral()
+		maven ("https://plugins.gradle.org/m2/")
+	}
+	dependencies {
+		classpath ("com.epages:restdocs-api-spec-gradle-plugin:0.11.3") //1.2
 	}
 }
 
@@ -105,6 +109,8 @@ subprojects {
 	}
 
 	if (project.name != "core") {
+		// Document
+		apply(plugin = "com.epages.restdocs-api-spec")
 
 		dependencies {
 			implementation(project(":core"))
@@ -152,7 +158,7 @@ subprojects {
 
 			// documentation
 			testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient:${springRestdocsVersion}")
-//            testImplementation("com.epages:restdocs-api-spec:0.8.2")
+            testImplementation("com.epages:restdocs-api-spec:0.11.3")
 
 			// MockK
 			testImplementation("io.mockk:mockk:1.10.0")

--- a/core/src/main/kotlin/com/sp/domain/product/entity/Product.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/Product.kt
@@ -5,23 +5,21 @@ import javax.persistence.*
 
 @Entity
 @Table( name = "product" )
-class Product (name: String, price: Int){
+class Product (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "product_no")
-    var no: Long = 0
+    var no: Long = 0,
 
     @Column(name="parent_no")
-    var parentNo: Long? = null
+    var parentNo: Long? = null,
 
     @Column(name = "name")
-    var name: String = name
+    var name: String,
 
     @Column(name = "price")
-    var price: Int = price
-
-    @OneToMany(mappedBy = "product")
-    var storeProduct: List<StoreProduct>? = null
+    var price: Int
+        ) {
 
     companion object{
         fun create(param: ProductRegisterModel) = Product(
@@ -29,5 +27,4 @@ class Product (name: String, price: Int){
             price = param.price
         )
     }
-
 }

--- a/core/src/main/kotlin/com/sp/domain/product/entity/Product.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/Product.kt
@@ -24,7 +24,8 @@ class Product (
     companion object{
         fun create(param: ProductRegisterModel) = Product(
             name = param.name,
-            price = param.price
+            price = param.price,
+            parentNo = param.parentNo
         )
     }
 }

--- a/core/src/main/kotlin/com/sp/domain/product/entity/Store.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/Store.kt
@@ -17,9 +17,6 @@ class Store (name: String, address: String){
     @Column(name= "address")
     var address: String = address
 
-    @OneToMany(mappedBy = "store")
-    var storeProduct: List<StoreProduct>? = null
-
     companion object {
         fun create(param: StoreRegisterModel) = Store(
             name = param.name,

--- a/core/src/main/kotlin/com/sp/domain/product/entity/StoreProduct.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/StoreProduct.kt
@@ -27,14 +27,18 @@ class StoreProduct (
     var modDate: LocalDateTime? = LocalDateTime.now(),
 
     @Column(name = "count")
-    var count: Int? = 0
+    var count: Int? = 0,
+
+    @Column(name = "member_no")
+    var memberNo: Long? = 0
 
     ){
     companion object{
         fun create(params: StoreProductRegisterModel) = StoreProduct(
             product = Product.create(params.product),
             store = Store.create(params.store),
-            count = params.count
+            count = params.count,
+            memberNo = params.memberNo
         )
     }
 }

--- a/core/src/main/kotlin/com/sp/domain/product/entity/StoreProduct.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/StoreProduct.kt
@@ -1,35 +1,40 @@
 package com.sp.domain.product.entity
 
-import java.util.*
+import com.sp.domain.product.entity.model.StoreProductRegisterModel
+import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
 @Table(name = "store_product")
-class StoreProduct (product: Product, store: Store){
-
+class StoreProduct (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "store_product_no")
-    var storeProductNo: Long? = null
+    var storeProductNo: Long? = null,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    var product: Product = product
+    @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_no")
+    var product: Product,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    var store: Store = store
+    @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @JoinColumn(name="store_no")
+    var store: Store,
 
     @Column(name = "reg_date")
-    var regDate: Date? = null
+    var regDate: LocalDateTime? = LocalDateTime.now(),
 
     @Column(name = "mod_date")
-    var modDate: Date? = null
+    var modDate: LocalDateTime? = LocalDateTime.now(),
 
+    @Column(name = "count")
+    var count: Int? = 0
+
+    ){
     companion object{
-        fun create(product:Product, store: Store) = StoreProduct(
-            product = product,
-            store = store
+        fun create(params: StoreProductRegisterModel) = StoreProduct(
+            product = Product.create(params.product),
+            store = Store.create(params.store),
+            count = params.count
         )
     }
 }

--- a/core/src/main/kotlin/com/sp/domain/product/entity/model/ProductRegisterModel.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/model/ProductRegisterModel.kt
@@ -2,5 +2,6 @@ package com.sp.domain.product.entity.model
 
 data class ProductRegisterModel(
     val name: String,
-    val price: Int
+    val price: Int,
+    val parentNo: Long
 )

--- a/core/src/main/kotlin/com/sp/domain/product/entity/model/StoreProductRegisterModel.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/model/StoreProductRegisterModel.kt
@@ -1,0 +1,10 @@
+package com.sp.domain.product.entity.model
+
+import com.sp.domain.product.entity.Product
+import com.sp.domain.product.entity.Store
+
+data class StoreProductRegisterModel(
+    val product: ProductRegisterModel,
+    val store: StoreRegisterModel,
+    val count: Int
+)

--- a/core/src/main/kotlin/com/sp/domain/product/entity/model/StoreProductRegisterModel.kt
+++ b/core/src/main/kotlin/com/sp/domain/product/entity/model/StoreProductRegisterModel.kt
@@ -6,5 +6,6 @@ import com.sp.domain.product.entity.Store
 data class StoreProductRegisterModel(
     val product: ProductRegisterModel,
     val store: StoreRegisterModel,
-    val count: Int
+    val count: Int,
+    val memberNo: Long
 )

--- a/front/build.gradle.kts
+++ b/front/build.gradle.kts
@@ -1,3 +1,17 @@
+import com.epages.restdocs.apispec.gradle.OpenApi3Extension
+
 dependencies {
     runtimeOnly("mysql:mysql-connector-java")
+}
+
+configure<OpenApi3Extension> {
+    setServer(rootProject.property("openapi.url") as String + ":8080")
+    title = "${rootProject.name}-${project.name}"
+    version = project.version as String
+    description = """
+                  | Mart front API
+                  """.trimMargin()
+    format = "yml"
+    separatePublicApi = true
+    outputFileNamePrefix = "${rootProject.name}-${project.name}"
 }

--- a/front/src/main/kotlin/com/sp/application/ProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/ProductService.kt
@@ -1,11 +1,8 @@
 package com.sp.application
 
 import com.sp.domain.product.ProductDomainService
-import com.sp.domain.product.entity.Product
 import com.sp.presentation.request.ProductRegisterRequest
 import org.springframework.stereotype.Service
-import java.util.*
-
 
 @Service
 class ProductService(

--- a/front/src/main/kotlin/com/sp/application/ProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/ProductService.kt
@@ -1,27 +1,16 @@
 package com.sp.application
 
-import com.sp.domain.ProductDomainService
+import com.sp.domain.product.ProductDomainService
 import com.sp.domain.product.entity.Product
 import com.sp.presentation.request.ProductRegisterRequest
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 
 @Service
-@Transactional(readOnly = true)
 class ProductService(
     private val productDomainService: ProductDomainService
 ) {
-    @Transactional
-    suspend fun findAllProducts():List<Product> {
-        return productDomainService.findAllProducts()
-    }
-
-    suspend fun findById(id: Long): Optional<Product> {
-        return productDomainService.findById(id)
-    }
-
     suspend fun registerProduct(params: ProductRegisterRequest): Long {
         return productDomainService.register(params)
     }

--- a/front/src/main/kotlin/com/sp/application/ProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/ProductService.kt
@@ -1,15 +1,25 @@
 package com.sp.application
 
+import com.sp.application.model.productRegisterApplicationModel
 import com.sp.domain.product.ProductDomainService
-import com.sp.presentation.request.ProductRegisterRequest
+import com.sp.domain.product.entity.Product
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
 
 @Service
 class ProductService(
-    private val productDomainService: ProductDomainService
+    private val productDomainService: ProductDomainService,
+    private val transactionTemplate: TransactionTemplate,
 ) {
-    suspend fun registerProduct(params: ProductRegisterRequest): Long {
-        return productDomainService.register(params)
+    suspend fun registerProduct(params: productRegisterApplicationModel): Long {
+        return productDomainService.register(params.valueOf())
+    }
+
+    suspend fun getAllProductList(): List<Product> {
+        val allProductList = productDomainService.findAllProducts()
+        return transactionTemplate.execute {
+            allProductList
+        }!!
     }
 
 }

--- a/front/src/main/kotlin/com/sp/application/ProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/ProductService.kt
@@ -1,6 +1,6 @@
 package com.sp.application
 
-import com.sp.application.model.productRegisterApplicationModel
+import com.sp.application.model.ProductRegisterApplicationModel
 import com.sp.domain.product.ProductDomainService
 import com.sp.domain.product.entity.Product
 import org.springframework.stereotype.Service
@@ -11,7 +11,7 @@ class ProductService(
     private val productDomainService: ProductDomainService,
     private val transactionTemplate: TransactionTemplate,
 ) {
-    suspend fun registerProduct(params: productRegisterApplicationModel): Long {
+    suspend fun registerProduct(params: ProductRegisterApplicationModel): Long {
         return productDomainService.register(params.valueOf())
     }
 

--- a/front/src/main/kotlin/com/sp/application/StoreProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/StoreProductService.kt
@@ -1,0 +1,12 @@
+package com.sp.application
+
+import com.sp.domain.product.entity.StoreProduct
+import com.sp.domain.storeProduct.StoreProductRepositoryImpl
+import org.springframework.stereotype.Service
+
+@Service
+class StoreProductService(private val spRepository: StoreProductRepositoryImpl) {
+    suspend fun getStoreList(name: String): List<StoreProduct> {
+        return spRepository.getStoreList(name, 2L)
+    }
+}

--- a/front/src/main/kotlin/com/sp/application/StoreProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/StoreProductService.kt
@@ -1,24 +1,26 @@
 package com.sp.application
 
+import com.sp.application.model.StoreProductRegisterApplicationModel
 import com.sp.domain.product.entity.StoreProduct
-import com.sp.domain.storeProduct.StoreProductRepository
-import com.sp.domain.storeProduct.StoreProductRepositorySupport
-import com.sp.presentation.request.ProductRegisterRequest
-import com.sp.presentation.request.StoreProductRegisterRequest
+import com.sp.domain.storeProduct.StoreProductDomainService
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.transaction.support.TransactionTemplate
 
 @Service
 class StoreProductService(
-    private val spRepository: StoreProductRepository,
-    private val spRepositorySupport: StoreProductRepositorySupport
+    private val storeProductDomainService: StoreProductDomainService,
+    private val transactionTemplate: TransactionTemplate,
+
     ) {
 
-    suspend fun register(params: StoreProductRegisterRequest): Long {
-        return spRepository.save(StoreProduct.create(params.valueOf())).storeProductNo!!
+    suspend fun register(params: StoreProductRegisterApplicationModel): Long {
+        return storeProductDomainService.register(params.valueOf())
     }
 
-    suspend fun getStoreList(name: String): List<StoreProduct> {
-        return spRepositorySupport.getStoreList(name, 2L)
+    suspend fun getStoreList(productNo: Long): List<StoreProduct> {
+        val allProductStoreList = storeProductDomainService.getStoreList(productNo)
+        return transactionTemplate.execute {
+            allProductStoreList
+        }!!
     }
 }

--- a/front/src/main/kotlin/com/sp/application/StoreProductService.kt
+++ b/front/src/main/kotlin/com/sp/application/StoreProductService.kt
@@ -1,12 +1,24 @@
 package com.sp.application
 
 import com.sp.domain.product.entity.StoreProduct
-import com.sp.domain.storeProduct.StoreProductRepositoryImpl
+import com.sp.domain.storeProduct.StoreProductRepository
+import com.sp.domain.storeProduct.StoreProductRepositorySupport
+import com.sp.presentation.request.ProductRegisterRequest
+import com.sp.presentation.request.StoreProductRegisterRequest
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.server.ServerRequest
 
 @Service
-class StoreProductService(private val spRepository: StoreProductRepositoryImpl) {
+class StoreProductService(
+    private val spRepository: StoreProductRepository,
+    private val spRepositorySupport: StoreProductRepositorySupport
+    ) {
+
+    suspend fun register(params: StoreProductRegisterRequest): Long {
+        return spRepository.save(StoreProduct.create(params.valueOf())).storeProductNo!!
+    }
+
     suspend fun getStoreList(name: String): List<StoreProduct> {
-        return spRepository.getStoreList(name, 2L)
+        return spRepositorySupport.getStoreList(name, 2L)
     }
 }

--- a/front/src/main/kotlin/com/sp/application/model/ProductRegisterApplicationModel.kt
+++ b/front/src/main/kotlin/com/sp/application/model/ProductRegisterApplicationModel.kt
@@ -2,7 +2,7 @@ package com.sp.application.model
 
 import com.sp.domain.product.entity.model.ProductRegisterModel
 
-data class productRegisterApplicationModel (
+data class ProductRegisterApplicationModel (
     val name: String,
     val price: Int,
     val parentNo: Long

--- a/front/src/main/kotlin/com/sp/application/model/StoreProductRegisterApplicationModel.kt
+++ b/front/src/main/kotlin/com/sp/application/model/StoreProductRegisterApplicationModel.kt
@@ -1,0 +1,22 @@
+package com.sp.application.model
+
+import com.sp.domain.product.entity.model.ProductRegisterModel
+import com.sp.domain.product.entity.model.StoreProductRegisterModel
+import com.sp.domain.product.entity.model.StoreRegisterModel
+
+data class StoreProductRegisterApplicationModel (
+    val productName: String,
+    val storeName: String,
+    val address: String,
+    val price: Int,
+    val parentNo: Long,
+    val count: Int,
+    val memberNo: Long
+    ) {
+    fun valueOf() = StoreProductRegisterModel(
+        product = ProductRegisterModel(productName, price, parentNo),
+        store = StoreRegisterModel(storeName, address),
+        count = count,
+        memberNo = memberNo
+    )
+}

--- a/front/src/main/kotlin/com/sp/application/model/productRegisterApplicationModel.kt
+++ b/front/src/main/kotlin/com/sp/application/model/productRegisterApplicationModel.kt
@@ -1,0 +1,15 @@
+package com.sp.application.model
+
+import com.sp.domain.product.entity.model.ProductRegisterModel
+
+data class productRegisterApplicationModel (
+    val name: String,
+    val price: Int,
+    val parentNo: Long
+) {
+    fun valueOf() = ProductRegisterModel(
+        name = name,
+        price = price,
+        parentNo = parentNo
+    )
+}

--- a/front/src/main/kotlin/com/sp/domain/product/ProductDomainService.kt
+++ b/front/src/main/kotlin/com/sp/domain/product/ProductDomainService.kt
@@ -1,7 +1,7 @@
 package com.sp.domain.product
 
 import com.sp.domain.product.entity.Product
-import com.sp.presentation.request.ProductRegisterRequest
+import com.sp.domain.product.entity.model.ProductRegisterModel
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -16,8 +16,8 @@ class ProductDomainService(private val productRepository: ProductRepository) {
         return productRepository.findById(id)
     }
 
-    suspend fun register(params: ProductRegisterRequest): Long {
-        return productRepository.save(Product.create(params.valueOf())).no
+    suspend fun register(params: ProductRegisterModel): Long {
+        return productRepository.save(Product.create(params)).no
     }
 }
 

--- a/front/src/main/kotlin/com/sp/domain/product/ProductDomainService.kt
+++ b/front/src/main/kotlin/com/sp/domain/product/ProductDomainService.kt
@@ -1,9 +1,8 @@
-package com.sp.domain
+package com.sp.domain.product
 
 import com.sp.domain.product.entity.Product
 import com.sp.presentation.request.ProductRegisterRequest
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Service

--- a/front/src/main/kotlin/com/sp/domain/product/ProductRepository.kt
+++ b/front/src/main/kotlin/com/sp/domain/product/ProductRepository.kt
@@ -1,4 +1,4 @@
-package com.sp.domain
+package com.sp.domain.product
 
 import com.sp.domain.product.entity.Product
 import org.springframework.data.jpa.repository.JpaRepository

--- a/front/src/main/kotlin/com/sp/domain/product/ProductRepository.kt
+++ b/front/src/main/kotlin/com/sp/domain/product/ProductRepository.kt
@@ -2,5 +2,7 @@ package com.sp.domain.product
 
 import com.sp.domain.product.entity.Product
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface ProductRepository : JpaRepository<Product, Long>

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/CustomizedStoreProductRepository.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/CustomizedStoreProductRepository.kt
@@ -1,0 +1,7 @@
+package com.sp.domain.storeProduct
+
+import com.sp.domain.product.entity.StoreProduct
+
+interface CustomizedStoreProductRepository {
+    fun getStoreList(productNo: Long): List<StoreProduct>
+}

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProducRespository.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProducRespository.kt
@@ -1,0 +1,7 @@
+package com.sp.domain.storeProduct
+
+import com.sp.domain.product.entity.StoreProduct
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
+
+interface StoreProducRespository: JpaRepository<StoreProduct, Long>, QuerydslPredicateExecutor<StoreProduct>

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductDomainService.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductDomainService.kt
@@ -1,0 +1,18 @@
+package com.sp.domain.storeProduct
+
+import com.sp.domain.product.entity.StoreProduct
+import com.sp.domain.product.entity.model.StoreProductRegisterModel
+import org.springframework.stereotype.Service
+
+@Service
+class StoreProductDomainService(
+    private val storeProductRepository: StoreProductRepository
+) {
+    suspend fun register(params: StoreProductRegisterModel): Long {
+        return storeProductRepository.save(StoreProduct.create(params)).storeProductNo!!
+    }
+
+    suspend fun getStoreList(productNo: Long): List<StoreProduct> {
+        return storeProductRepository.getStoreList(productNo)
+    }
+}

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepository.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepository.kt
@@ -3,5 +3,7 @@ package com.sp.domain.storeProduct
 import com.sp.domain.product.entity.StoreProduct
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.querydsl.QuerydslPredicateExecutor
+import org.springframework.stereotype.Repository
 
-interface StoreProductRepository: JpaRepository<StoreProduct, Long>, QuerydslPredicateExecutor<StoreProduct>
+@Repository
+interface StoreProductRepository: JpaRepository<StoreProduct, Long>, CustomizedStoreProductRepository

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepository.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepository.kt
@@ -4,4 +4,4 @@ import com.sp.domain.product.entity.StoreProduct
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
-interface StoreProducRespository: JpaRepository<StoreProduct, Long>, QuerydslPredicateExecutor<StoreProduct>
+interface StoreProductRepository: JpaRepository<StoreProduct, Long>, QuerydslPredicateExecutor<StoreProduct>

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImpl.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.sp.domain.storeProduct
+
+import com.querydsl.core.types.Predicate
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sp.domain.product.entity.QProduct.product
+import com.sp.domain.product.entity.QStoreProduct
+import com.sp.domain.product.entity.StoreProduct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+import javax.annotation.Resource
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Repository
+class StoreProductRepositoryImpl(
+    @Autowired
+    @Resource(name = "jpaQueryFactory")
+    var query : JPAQueryFactory
+    ): QuerydslRepositorySupport(StoreProduct::class.java) {
+
+    val storeProduct = QStoreProduct.storeProduct
+
+    fun getStoreList(name: String, pageSize: Long) :List<StoreProduct> {
+        return query
+            .select(storeProduct)
+            .from(storeProduct)
+            .where(storeProduct.product.name.containsIgnoreCase(name))
+            .limit(pageSize)
+            .fetch()
+    }
+}

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImpl.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImpl.kt
@@ -1,32 +1,26 @@
 package com.sp.domain.storeProduct
 
-import com.querydsl.core.types.Predicate
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.sp.domain.product.entity.QProduct.product
 import com.sp.domain.product.entity.QStoreProduct
 import com.sp.domain.product.entity.StoreProduct
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
-import org.springframework.stereotype.Repository
 import javax.annotation.Resource
-import javax.persistence.EntityManager
-import javax.persistence.PersistenceContext
 
-@Repository
-class StoreProductRepositorySupport(
+
+class StoreProductRepositoryImpl(
     @Autowired
     @Resource(name = "jpaQueryFactory")
     var query : JPAQueryFactory
-    ): QuerydslRepositorySupport(StoreProduct::class.java) {
+    ): QuerydslRepositorySupport(StoreProduct::class.java), CustomizedStoreProductRepository {
 
     val storeProduct = QStoreProduct.storeProduct
 
-    fun getStoreList(name: String, pageSize: Long) :List<StoreProduct> {
+    override fun getStoreList(productNo: Long): List<StoreProduct> {
         return query
             .select(storeProduct)
             .from(storeProduct)
-            .where(storeProduct.product.name.containsIgnoreCase(name))
-            .limit(pageSize)
+            .where(storeProduct.product.no.eq(productNo))
             .fetch()
     }
 }

--- a/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositorySupport.kt
+++ b/front/src/main/kotlin/com/sp/domain/storeProduct/StoreProductRepositorySupport.kt
@@ -13,7 +13,7 @@ import javax.persistence.EntityManager
 import javax.persistence.PersistenceContext
 
 @Repository
-class StoreProductRepositoryImpl(
+class StoreProductRepositorySupport(
     @Autowired
     @Resource(name = "jpaQueryFactory")
     var query : JPAQueryFactory

--- a/front/src/main/kotlin/com/sp/infrastructure/queryDslConfig.kt
+++ b/front/src/main/kotlin/com/sp/infrastructure/queryDslConfig.kt
@@ -1,0 +1,19 @@
+package com.sp.infrastructure
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+
+@Configuration
+class queryDslConfig {
+    @PersistenceContext
+    private val entityManager: EntityManager? = null
+
+    @Bean
+    open fun jpaQueryFactory(): JPAQueryFactory? {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/front/src/main/kotlin/com/sp/presentation/FrontApiTestSupportFilterFunction.kt
+++ b/front/src/main/kotlin/com/sp/presentation/FrontApiTestSupportFilterFunction.kt
@@ -1,0 +1,24 @@
+package com.sp.presentation
+
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Mono
+
+class FrontApiTestSupportFilterFunction : ExchangeFilterFunction {
+    override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+        val url = request.url()
+        val backendUrl = UriComponentsBuilder.fromUri(url)
+            .replacePath("/backend${url.path}")
+            .replaceQuery(url.query)
+            .build()
+            .toUri()
+        return next.exchange(
+            ClientRequest.from(request)
+                .url(backendUrl)
+                .build()
+        )
+    }
+}

--- a/front/src/main/kotlin/com/sp/presentation/handler/ProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/ProductHandler.kt
@@ -1,7 +1,6 @@
 package com.sp.presentation.handler
 
 import com.sp.application.ProductService
-import com.sp.domain.ProductRepository
 import com.sp.presentation.request.ProductRegisterRequest
 import org.springframework.stereotype.*
 import org.springframework.web.reactive.function.server.*
@@ -12,12 +11,6 @@ import java.net.URI
 class ProductHandler (
     private val productService: ProductService
 ) {
-    suspend fun findAll(request: ServerRequest): ServerResponse =
-        ServerResponse.ok().json().bodyValueAndAwait(productService.findAllProducts())
-
-    suspend fun findById(request: ServerRequest): ServerResponse =
-            ServerResponse.ok().json().bodyValueAndAwait(productService.findById(request.pathVariable("id").toLong()))
-
     suspend fun register(request: ServerRequest): ServerResponse {
         val params = request.awaitBody<ProductRegisterRequest>()
         val memberNo = productService.registerProduct(params)

--- a/front/src/main/kotlin/com/sp/presentation/handler/ProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/ProductHandler.kt
@@ -13,7 +13,11 @@ class ProductHandler (
 ) {
     suspend fun register(request: ServerRequest): ServerResponse {
         val params = request.awaitBody<ProductRegisterRequest>()
-        val memberNo = productService.registerProduct(params)
-        return created(URI.create(memberNo.toString())).buildAndAwait()
+        val productNo = productService.registerProduct(params.valueOf())
+        return created(URI.create(productNo.toString())).buildAndAwait()
     }
+
+    suspend fun getAllProductList(request: ServerRequest): ServerResponse =
+        ServerResponse.ok().json().bodyValueAndAwait(productService.getAllProductList())
+
 }

--- a/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
@@ -1,16 +1,23 @@
 package com.sp.presentation.handler
 
 import com.sp.application.StoreProductService
-import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.bodyValueAndAwait
-import org.springframework.web.reactive.function.server.json
+import com.sp.presentation.request.ProductRegisterRequest
+import com.sp.presentation.request.StoreProductRegisterRequest
+import org.springframework.stereotype.*
+import org.springframework.web.reactive.function.server.*
+import org.springframework.web.reactive.function.server.ServerResponse.*
+import java.net.URI
 
 @Component
 class StoreProductHandler(
     private val storeProductService: StoreProductService
 ) {
+    suspend fun register(request: ServerRequest): ServerResponse {
+        val params = request.awaitBody<StoreProductRegisterRequest>()
+        val storeProductNo = storeProductService.register(params)
+        return created(URI.create(storeProductNo.toString())).buildAndAwait()
+    }
+
     suspend fun getStoreList(request: ServerRequest): ServerResponse =
         ServerResponse.ok().json().bodyValueAndAwait(storeProductService.getStoreList(request.pathVariable("name")))
 }

--- a/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
@@ -1,0 +1,16 @@
+package com.sp.presentation.handler
+
+import com.sp.application.StoreProductService
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.json
+
+@Component
+class StoreProductHandler(
+    private val storeProductService: StoreProductService
+) {
+    suspend fun getStoreList(request: ServerRequest): ServerResponse =
+        ServerResponse.ok().json().bodyValueAndAwait(storeProductService.getStoreList(request.pathVariable("name")))
+}

--- a/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
+++ b/front/src/main/kotlin/com/sp/presentation/handler/StoreProductHandler.kt
@@ -1,7 +1,6 @@
 package com.sp.presentation.handler
 
 import com.sp.application.StoreProductService
-import com.sp.presentation.request.ProductRegisterRequest
 import com.sp.presentation.request.StoreProductRegisterRequest
 import org.springframework.stereotype.*
 import org.springframework.web.reactive.function.server.*
@@ -14,10 +13,10 @@ class StoreProductHandler(
 ) {
     suspend fun register(request: ServerRequest): ServerResponse {
         val params = request.awaitBody<StoreProductRegisterRequest>()
-        val storeProductNo = storeProductService.register(params)
+        val storeProductNo = storeProductService.register(params.valueOf())
         return created(URI.create(storeProductNo.toString())).buildAndAwait()
     }
 
     suspend fun getStoreList(request: ServerRequest): ServerResponse =
-        ServerResponse.ok().json().bodyValueAndAwait(storeProductService.getStoreList(request.pathVariable("name")))
+        ServerResponse.ok().json().bodyValueAndAwait(storeProductService.getStoreList(request.pathVariable("id").toLong()))
 }

--- a/front/src/main/kotlin/com/sp/presentation/request/ProductRegisterRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/ProductRegisterRequest.kt
@@ -4,10 +4,12 @@ import com.sp.domain.product.entity.model.ProductRegisterModel
 
 data class ProductRegisterRequest(
     val name: String,
-    val price: Int
+    val price: Int,
+    val parentNo: Long
 ) {
     fun valueOf() = ProductRegisterModel(
         name = name,
-        price = price
+        price = price,
+        parentNo = parentNo
     )
 }

--- a/front/src/main/kotlin/com/sp/presentation/request/ProductRegisterRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/ProductRegisterRequest.kt
@@ -1,13 +1,14 @@
 package com.sp.presentation.request
 
-import com.sp.domain.product.entity.model.ProductRegisterModel
+import com.sp.application.model.productRegisterApplicationModel
+
 
 data class ProductRegisterRequest(
     val name: String,
     val price: Int,
     val parentNo: Long
 ) {
-    fun valueOf() = ProductRegisterModel(
+    fun valueOf() = productRegisterApplicationModel(
         name = name,
         price = price,
         parentNo = parentNo

--- a/front/src/main/kotlin/com/sp/presentation/request/ProductRegisterRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/ProductRegisterRequest.kt
@@ -1,6 +1,6 @@
 package com.sp.presentation.request
 
-import com.sp.application.model.productRegisterApplicationModel
+import com.sp.application.model.ProductRegisterApplicationModel
 
 
 data class ProductRegisterRequest(
@@ -8,7 +8,7 @@ data class ProductRegisterRequest(
     val price: Int,
     val parentNo: Long
 ) {
-    fun valueOf() = productRegisterApplicationModel(
+    fun valueOf() = ProductRegisterApplicationModel(
         name = name,
         price = price,
         parentNo = parentNo

--- a/front/src/main/kotlin/com/sp/presentation/request/StoreProductRegisterRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/StoreProductRegisterRequest.kt
@@ -1,0 +1,20 @@
+package com.sp.presentation.request
+
+import com.sp.domain.product.entity.model.ProductRegisterModel
+import com.sp.domain.product.entity.model.StoreProductRegisterModel
+import com.sp.domain.product.entity.model.StoreRegisterModel
+
+data class StoreProductRegisterRequest(
+    val productName: String,
+    val storeName: String,
+    val address: String,
+    val price: Int,
+    val parentNo: Long,
+    val count: Int
+) {
+    fun valueOf() = StoreProductRegisterModel(
+        product = ProductRegisterModel(productName, price, parentNo),
+        store = StoreRegisterModel(storeName, address),
+        count = count
+    )
+}

--- a/front/src/main/kotlin/com/sp/presentation/request/StoreProductRegisterRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/StoreProductRegisterRequest.kt
@@ -1,8 +1,6 @@
 package com.sp.presentation.request
 
-import com.sp.domain.product.entity.model.ProductRegisterModel
-import com.sp.domain.product.entity.model.StoreProductRegisterModel
-import com.sp.domain.product.entity.model.StoreRegisterModel
+import com.sp.application.model.StoreProductRegisterApplicationModel
 
 data class StoreProductRegisterRequest(
     val productName: String,
@@ -10,11 +8,17 @@ data class StoreProductRegisterRequest(
     val address: String,
     val price: Int,
     val parentNo: Long,
-    val count: Int
+    val count: Int,
+    val memberNo: Long
 ) {
-    fun valueOf() = StoreProductRegisterModel(
-        product = ProductRegisterModel(productName, price, parentNo),
-        store = StoreRegisterModel(storeName, address),
-        count = count
+    fun valueOf() = StoreProductRegisterApplicationModel(
+        productName = productName,
+        storeName = storeName,
+        address = address,
+        price = price,
+        count = count,
+        parentNo = parentNo,
+        memberNo = memberNo
+
     )
 }

--- a/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
+++ b/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
@@ -19,8 +19,19 @@ class ProductRouter(
             ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
                 accept(MediaType.APPLICATION_JSON).nest {
                     POST("", productHandler::register)
-                    POST("/storeProduct", storeProductHandler::register)
-                    GET("/{name}", storeProductHandler::getStoreList)
+                    GET("/allList", productHandler::getAllProductList)
+                }
+            }
+        }
+    }
+
+    @Bean
+    fun routeStoreProductGet(): RouterFunction<ServerResponse> {
+        return coRouter {
+            ("/backend/storeProduct" and headers { "1.0" in it.header("Version") }).nest {
+                accept(MediaType.APPLICATION_JSON).nest {
+                    POST("", storeProductHandler::register)
+                    GET("/{id}", storeProductHandler::getStoreList)
                 }
             }
         }

--- a/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
+++ b/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
@@ -19,6 +19,7 @@ class ProductRouter(
             ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
                 accept(MediaType.APPLICATION_JSON).nest {
                     POST("", productHandler::register)
+                    POST("/storeProduct", storeProductHandler::register)
                     GET("/{name}", storeProductHandler::getStoreList)
                 }
             }

--- a/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
+++ b/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
@@ -1,31 +1,25 @@
 package com.sp.presentation.router
 
 import com.sp.presentation.handler.ProductHandler
+import com.sp.presentation.handler.StoreProductHandler
 import org.springframework.context.annotation.*
 import org.springframework.http.*
 import org.springframework.web.reactive.function.server.*
 import reactor.core.publisher.Mono
 
 @Configuration
-class ProductRouter(private val productHandler: ProductHandler) {
+class ProductRouter(
+    private val productHandler: ProductHandler,
+    private val storeProductHandler: StoreProductHandler
+) {
 
     @Bean
     fun routeProductGet(): RouterFunction<ServerResponse> {
         return coRouter {
             ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
                 accept(MediaType.APPLICATION_JSON).nest {
-                    GET("", productHandler::findAll)
-                }
-            }
-        }
-    }
-
-    @Bean
-    fun routeProductPost(): RouterFunction<ServerResponse> {
-        return coRouter {
-            ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
-                accept(MediaType.APPLICATION_JSON).nest {
                     POST("", productHandler::register)
+                    GET("/{name}", storeProductHandler::getStoreList)
                 }
             }
         }

--- a/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
+++ b/front/src/main/kotlin/com/sp/presentation/router/ProductRouter.kt
@@ -19,7 +19,7 @@ class ProductRouter(
             ("/backend/product" and headers { "1.0" in it.header("Version") }).nest {
                 accept(MediaType.APPLICATION_JSON).nest {
                     POST("", productHandler::register)
-                    GET("/allList", productHandler::getAllProductList)
+                    GET("/list", productHandler::getAllProductList)
                 }
             }
         }

--- a/front/src/main/resources/bootstrap.yml
+++ b/front/src/main/resources/bootstrap.yml
@@ -18,7 +18,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-#      ddl-auto: create
+      ddl-auto: none
       naming:
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyHbmImpl
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/front/src/test/kotlin/com/sp/application/ProductServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/ProductServiceTest.kt
@@ -1,6 +1,6 @@
 package com.sp.application
 
-import com.sp.domain.ProductDomainService
+import com.sp.domain.product.ProductDomainService
 import com.sp.presentation.request.*
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
@@ -8,7 +8,6 @@ import io.mockk.junit5.*
 import kotlinx.coroutines.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.*
-import org.junit.jupiter.api.Assertions.*
 
 /**
  * @author sojeong park
@@ -30,7 +29,8 @@ internal class ProductServiceTest {
         //given
         val request = ProductRegisterRequest(
             name = "koko",
-            price = 1500
+            price = 1500,
+            parentNo = 1L
         )
 
         //when

--- a/front/src/test/kotlin/com/sp/application/ProductServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/ProductServiceTest.kt
@@ -1,13 +1,14 @@
 package com.sp.application
 
+import com.sp.application.model.ProductRegisterApplicationModel
 import com.sp.domain.product.ProductDomainService
-import com.sp.presentation.request.*
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.*
 import kotlinx.coroutines.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.*
+import org.springframework.transaction.support.*
 
 /**
  * @author sojeong park
@@ -17,17 +18,24 @@ internal class ProductServiceTest {
     @MockK
     private lateinit var productDomainService: ProductDomainService
 
+    @MockK
+    private lateinit var transactionTemplate: TransactionTemplate
+
     private lateinit var productService: ProductService
 
     @BeforeEach
     fun setUp(){
-        productService = ProductService(productDomainService)
+        productService = ProductService(productDomainService, transactionTemplate)
+
+        every { transactionTemplate.execute(any<TransactionCallback<*>>()) } answers {
+            (firstArg() as TransactionCallback<*>).doInTransaction(mockk())
+        }
     }
 
     @Test
     fun `상품등록`(){
         //given
-        val request = ProductRegisterRequest(
+        val request = ProductRegisterApplicationModel(
             name = "koko",
             price = 1500,
             parentNo = 1L
@@ -40,5 +48,15 @@ internal class ProductServiceTest {
         //then
         coVerify { productService.registerProduct(any()) }
 
+    }
+
+    @Test
+    fun `상품전체조회`(){
+        //when
+        coEvery { productDomainService.findAllProducts() } returns listOf()
+        runBlocking { productService.getAllProductList() }
+
+        //then
+        coVerify { productService.getAllProductList() }
     }
 }

--- a/front/src/test/kotlin/com/sp/application/StoreProductServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/StoreProductServiceTest.kt
@@ -1,14 +1,16 @@
 package com.sp.application
 
-import com.sp.domain.product.ProductDomainService
-import com.sp.domain.storeProduct.StoreProductRepositoryImpl
+import com.ninjasquad.springmockk.MockkBean
+import com.sp.domain.product.entity.StoreProduct
+import com.sp.domain.storeProduct.StoreProductRepository
+import com.sp.domain.storeProduct.StoreProductRepositorySupport
 import com.sp.presentation.request.ProductRegisterRequest
+import com.sp.presentation.request.StoreProductRegisterRequest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -16,13 +18,16 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 internal class StoreProductServiceTest {
     @MockK
-    private lateinit var storeProductRepositoryImpl: StoreProductRepositoryImpl
+    private lateinit var storeProductRepositorySupport: StoreProductRepositorySupport
+
+    @MockK
+    private lateinit var spRepository: StoreProductRepository
 
     private lateinit var storeProductService: StoreProductService
 
     @BeforeEach
     fun setUp(){
-        storeProductService = StoreProductService(storeProductRepositoryImpl)
+        storeProductService = StoreProductService(spRepository, storeProductRepositorySupport)
     }
 
     @Test
@@ -30,10 +35,33 @@ internal class StoreProductServiceTest {
         //given
 
         //when
-        coEvery { storeProductRepositoryImpl.getStoreList(any(), 1L) } returns listOf()
+        coEvery { storeProductRepositorySupport.getStoreList(any(), 1L) } returns listOf()
         runBlocking { storeProductService.getStoreList("koko") }
 
         //then
         coVerify { storeProductService.getStoreList("koko") }
+    }
+
+    @Test
+    fun `상품 상점 등록`(){
+        //given
+        val storeProduct = StoreProductRegisterRequest(
+            productName= "초코맛",
+            storeName= "GS24",
+            address= "고척1동",
+            price= 1500,
+            parentNo= 1L,
+            count= 2
+        )
+
+        //when
+        //val saved = storeProductRepository.save(StoreProduct.create(storeProduct.valueOf())).storeProductNo!!
+
+        coEvery { spRepository.save(any()).storeProductNo } returns 1L
+        runBlocking { storeProductService.register(storeProduct) }
+
+        //then
+        coVerify { storeProductService.register(any()) }
+
     }
 }

--- a/front/src/test/kotlin/com/sp/application/StoreProductServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/StoreProductServiceTest.kt
@@ -1,0 +1,39 @@
+package com.sp.application
+
+import com.sp.domain.product.ProductDomainService
+import com.sp.domain.storeProduct.StoreProductRepositoryImpl
+import com.sp.presentation.request.ProductRegisterRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class StoreProductServiceTest {
+    @MockK
+    private lateinit var storeProductRepositoryImpl: StoreProductRepositoryImpl
+
+    private lateinit var storeProductService: StoreProductService
+
+    @BeforeEach
+    fun setUp(){
+        storeProductService = StoreProductService(storeProductRepositoryImpl)
+    }
+
+    @Test
+    fun `상품명으로 상점 리스트 조회`(){
+        //given
+
+        //when
+        coEvery { storeProductRepositoryImpl.getStoreList(any(), 1L) } returns listOf()
+        runBlocking { storeProductService.getStoreList("koko") }
+
+        //then
+        coVerify { storeProductService.getStoreList("koko") }
+    }
+}

--- a/front/src/test/kotlin/com/sp/domain/product/ProductRepositoryTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/product/ProductRepositoryTest.kt
@@ -35,4 +35,11 @@ class ProductRepositoryTest(
         assertEquals(product.name, result.name)
         assertEquals(product.price, result.price)
     }
+
+    @Test
+    fun `상품 전체 조회`(){
+        val result = productRepository.findAll()
+
+        println(result.size)
+    }
 }

--- a/front/src/test/kotlin/com/sp/domain/product/ProductRepositoryTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/product/ProductRepositoryTest.kt
@@ -1,9 +1,9 @@
-package com.sp.domain
+package com.sp.domain.product
 
+import com.sp.domain.product.ProductRepository
 import com.sp.domain.product.entity.Product
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.*
 import org.springframework.boot.test.autoconfigure.jdbc.*
 import org.springframework.boot.test.autoconfigure.orm.jpa.*
 import org.springframework.context.annotation.*

--- a/front/src/test/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImplTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImplTest.kt
@@ -1,10 +1,10 @@
 package com.sp.domain.storeProduct
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sp.application.model.StoreProductRegisterApplicationModel
 import org.junit.jupiter.api.Assertions.*
 import com.sp.domain.product.entity.StoreProduct
 import com.sp.infrastructure.queryDslConfig
-import com.sp.presentation.request.StoreProductRegisterRequest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ import javax.annotation.Resource
 class StoreProductRepositoryImplTest(
     val storeProductRepository: StoreProductRepository
 ) {
-    private lateinit var spRepositoryImpl: StoreProductRepositorySupport
+    private lateinit var spRepositoryImpl: StoreProductRepositoryImpl
 
     @Autowired
     @Resource(name = "jpaQueryFactory")
@@ -35,12 +35,12 @@ class StoreProductRepositoryImplTest(
 
     @BeforeEach
     fun setUp(){
-        spRepositoryImpl = StoreProductRepositorySupport(query)
+        spRepositoryImpl = StoreProductRepositoryImpl(query)
     }
     @Test
-    fun `상품명으로 상점 리스트 조회`(){
+    fun `상품 no로 상점 리스트 조회`(){
         //when
-        val storeList = spRepositoryImpl.getStoreList("koko", 1L)
+        val storeList = spRepositoryImpl.getStoreList(1L)
 
         //then
         Assertions.assertEquals(storeList.get(0).store.name, "GS25")
@@ -50,15 +50,15 @@ class StoreProductRepositoryImplTest(
     @Test
     fun `상품 상점 등록`(){
         //given
-        val storeProduct = StoreProductRegisterRequest(
+        val storeProduct = StoreProductRegisterApplicationModel(
             productName= "초코맛",
             storeName= "GS24",
             address= "고척1동",
             price= 1500,
             parentNo= 1L,
-            count= 2
+            count= 2,
+            memberNo = 1L
         )
-
         //when
         val saved = storeProductRepository.save(StoreProduct.create(storeProduct.valueOf())).storeProductNo!!
 

--- a/front/src/test/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImplTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/storeProduct/StoreProductRepositoryImplTest.kt
@@ -1,0 +1,49 @@
+package com.sp.domain.storeProduct
+
+import com.ninjasquad.springmockk.MockkBean
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sp.application.StoreProductService
+import com.sp.domain.extensions.toJson
+import com.sp.domain.product.entity.QStoreProduct
+import com.sp.infrastructure.queryDslConfig
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.stereotype.Repository
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
+import javax.annotation.Resource
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ComponentScan(useDefaultFilters = false, includeFilters = [ComponentScan.Filter(Repository::class)])
+@Import(queryDslConfig::class)
+class StoreProductRepositoryImplTest{
+    private lateinit var spRepositoryImpl: StoreProductRepositoryImpl
+
+    @Autowired
+    @Resource(name = "jpaQueryFactory")
+    lateinit var query : JPAQueryFactory
+
+    @BeforeEach
+    fun setUp(){
+        spRepositoryImpl = StoreProductRepositoryImpl(query)
+    }
+    @Test
+    fun `상품명으로 상점 리스트 조회`(){
+        //when
+        val storeList = spRepositoryImpl.getStoreList("koko", 1L)
+
+        //then
+        Assertions.assertEquals(storeList.get(0).store.name, "GS25")
+        Assertions.assertEquals(storeList.get(0).store.address, "고척1동")
+    }
+}

--- a/front/src/test/kotlin/com/sp/presentation/handler/ProductHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/ProductHandlerTest.kt
@@ -36,7 +36,8 @@ internal class ProductHandlerTest {
     fun `상품등록`() {
         val requestBody = ProductRegisterRequest(
             name = "꼬북칩",
-            price = 1500
+            price = 1500,
+            parentNo=1L
         )
         val request = MockServerHttpRequest
             .post("/backend/product")

--- a/front/src/test/kotlin/com/sp/presentation/handler/ProductHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/ProductHandlerTest.kt
@@ -58,4 +58,24 @@ internal class ProductHandlerTest {
 
         coVerify { productService.registerProduct(any()) }
     }
+
+    @Test
+    fun `상품 전체 조회`(){
+        val request = MockServerHttpRequest
+            .get("/backend/product")
+
+        val exchange = MockServerWebExchange
+            .from(request)
+            .let{ ServerRequest.create(it, HandlerStrategies.withDefaults().messageReaders()) }
+
+        coEvery { productService.getAllProductList() } returns listOf()
+
+        //when
+        val response = runBlocking { productHandler.getAllProductList(exchange) }
+
+        //then
+        assertEquals(HttpStatus.OK, response.statusCode())
+
+        coVerify { productService.getAllProductList() }
+    }
 }

--- a/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
@@ -1,6 +1,8 @@
 package com.sp.presentation.handler
 
 import com.sp.application.StoreProductService
+import com.sp.domain.extensions.toJson
+import com.sp.presentation.request.StoreProductRegisterRequest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.web.reactive.function.server.HandlerStrategies
@@ -53,5 +56,36 @@ internal class StoreProductHandlerTest{
         assertEquals(HttpStatus.CREATED, response.statusCode())
 
         coVerify { storeProductService.getStoreList(any()) }
+    }
+
+    @Test
+    fun `상품등록`() {
+        val requestBody = StoreProductRegisterRequest(
+            productName= "초코맛",
+            storeName= "GS24",
+            address= "고척1동",
+            price= 1500,
+            parentNo= 1L,
+            count= 2
+        )
+
+        val request = MockServerHttpRequest
+            .post("/backend/product/storeProduct")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBody.toJson())
+
+        val exchange = MockServerWebExchange
+            .from(request)
+            .let{ ServerRequest.create(it, HandlerStrategies.withDefaults().messageReaders()) }
+
+        coEvery { storeProductService.register(any()) } returns 1L
+
+        //when
+        val response = runBlocking { storeProductHandler.register(exchange) }
+
+        //then
+        assertEquals(HttpStatus.CREATED, response.statusCode())
+
+        coVerify { storeProductService.register(any()) }
     }
 }

--- a/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
@@ -41,7 +41,7 @@ internal class StoreProductHandlerTest{
     @Test
     fun `상품명으로 상점 리스트 조회`(){
         val request = MockServerHttpRequest
-            .get("/backend/product/koko")
+            .get("/backend/product/1L")
 
         val exchange = MockServerWebExchange
             .from(request)
@@ -66,7 +66,8 @@ internal class StoreProductHandlerTest{
             address= "고척1동",
             price= 1500,
             parentNo= 1L,
-            count= 2
+            count= 2,
+            memberNo = 1L
         )
 
         val request = MockServerHttpRequest

--- a/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/StoreProductHandlerTest.kt
@@ -1,0 +1,57 @@
+package com.sp.presentation.handler
+
+import com.sp.application.StoreProductService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.reactive.function.server.HandlerStrategies
+import org.springframework.web.reactive.function.server.ServerRequest
+
+@ExtendWith(MockKExtension::class)
+internal class StoreProductHandlerTest{
+    @MockK
+    private lateinit var storeProductService: StoreProductService
+
+    private lateinit var storeProductHandler: StoreProductHandler
+
+    @BeforeEach
+    internal fun setUp(){
+        storeProductHandler = StoreProductHandler(storeProductService)
+    }
+
+    @AfterEach
+    internal fun after(){
+        unmockkAll()
+    }
+
+    @Test
+    fun `상품명으로 상점 리스트 조회`(){
+        val request = MockServerHttpRequest
+            .get("/backend/product/koko")
+
+        val exchange = MockServerWebExchange
+            .from(request)
+            .let{ ServerRequest.create(it, HandlerStrategies.withDefaults().messageReaders())}
+
+        coEvery { storeProductService.getStoreList(any()) } returns listOf()
+
+        //when
+        val response = runBlocking { storeProductHandler.getStoreList(exchange) }
+
+        //then
+        assertEquals(HttpStatus.CREATED, response.statusCode())
+
+        coVerify { storeProductService.getStoreList(any()) }
+    }
+}

--- a/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
@@ -2,11 +2,10 @@ package com.sp.presentation.router
 
 import com.ninjasquad.springmockk.*
 import com.sp.application.*
-import com.sp.domain.product.entity.Product
-import com.sp.domain.product.entity.StoreProduct
 import com.sp.presentation.handler.ProductHandler
 import com.sp.presentation.handler.StoreProductHandler
 import com.sp.presentation.request.ProductRegisterRequest
+import com.sp.presentation.request.StoreProductRegisterRequest
 import io.mockk.coEvery
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -45,7 +44,8 @@ internal class ProductRouterTest(private val context: ApplicationContext){
     fun `부모 상품 등록`() {
         val request = ProductRegisterRequest(
             name = "꼬북칩",
-            price = 1500
+            price = 1500,
+            parentNo = 1L
         )
 
         coEvery { productService.registerProduct(any()) } returns 1L
@@ -73,5 +73,28 @@ internal class ProductRouterTest(private val context: ApplicationContext){
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().isOk
+    }
+
+    @Test
+    fun `상품 상점 등록`(){
+        val request = StoreProductRegisterRequest(
+            productName= "초코맛",
+            storeName= "GS24",
+            address= "고척1동",
+            price= 1500,
+            parentNo= 1L,
+            count= 2
+        )
+
+        coEvery { storeProductService.register(any()) } returns 1L
+
+        webTestClient.post()
+            .uri("/backend/product/storeProduct")
+            .header("Version", "1.0")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus().isCreated
     }
 }

--- a/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
@@ -19,6 +19,10 @@ import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.reactive.server.WebTestClient
+import com.sp.presentation.FrontApiTestSupportFilterFunction
+import com.epages.restdocs.apispec.*
+import com.sp.presentation.*
+import org.springframework.restdocs.payload.*
 
 @WebFluxTest
 @ExtendWith(RestDocumentationExtension::class)
@@ -32,16 +36,20 @@ internal class ProductRouterTest(private val context: ApplicationContext){
     @MockkBean
     private lateinit var storeProductService: StoreProductService
 
+    private val TAG = "PRODUCT"
+
     @BeforeEach
     fun setup(restDocumentation: RestDocumentationContextProvider) {
         webTestClient = WebTestClient.bindToApplicationContext(context)
             .configureClient()
             .baseUrl("http://localhost:8080")
             .filter(WebTestClientRestDocumentation.documentationConfiguration(restDocumentation))
+            .filter(FrontApiTestSupportFilterFunction())
             .build()
     }
     @Test
-    fun `부모 상품 등록`() {
+    fun `상품 등록`() {
+        val productNo = 1L
         val request = ProductRegisterRequest(
             name = "꼬북칩",
             price = 1500,
@@ -51,39 +59,76 @@ internal class ProductRouterTest(private val context: ApplicationContext){
         coEvery { productService.registerProduct(any()) } returns 1L
 
         webTestClient.post()
-            .uri("/backend/product")
+            .uri("/product")
             .header("Version", "1.0")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .bodyValue(request)
             .exchange()
             .expectStatus().isCreated
+            .expectHeader().valueEquals(HttpHeaders.LOCATION, productNo.toString())
+            .expectBody().consumeWith(
+                WebTestClientRestDocumentation.document(
+                    "product-register",
+                    ResourceDocumentation.resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(TAG)
+                            .description("상품 등록")
+                            .requestFields(
+                                PayloadDocumentation.fieldWithPath("name")
+                                    .description("상품명")
+                                    .type(JsonFieldType.STRING),
+                                PayloadDocumentation.fieldWithPath("price")
+                                    .description("가격")
+                                    .type(JsonFieldType.NUMBER),
+                                PayloadDocumentation.fieldWithPath("parentNo")
+                                    .description("부모 product 번호")
+                                    .type(JsonFieldType.NUMBER)
+                            ).build()
+                    )
+                )
+            )
     }
 
     @Test
-    fun `상품명으로 상점 리스트 조회`() {
-        val productName = "koko"
+    fun `상품 no로 상점 리스트 조회`() {
+        val productNo = 1L
 
         coEvery { storeProductService.getStoreList(any()) } returns listOf()
 
         webTestClient.get()
-            .uri("/backend/product/"+productName)
+            .uri("/backend/product/" + productNo)
             .header("Version", "1.0")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().isOk
+            .expectHeader().valueEquals(HttpHeaders.LOCATION, productNo.toString())
+            .expectBody().consumeWith(
+                WebTestClientRestDocumentation.document(
+                    "product-no-find-all-store-list",
+                    ResourceDocumentation.resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(TAG)
+                            .description("상품 번호로 상점 리스트 조회")
+                            .build()
+                    )
+                )
+            )
+
     }
 
     @Test
     fun `상품 상점 등록`(){
+        val storeProductNo = 1L
         val request = StoreProductRegisterRequest(
             productName= "초코맛",
             storeName= "GS24",
             address= "고척1동",
             price= 1500,
             parentNo= 1L,
-            count= 2
+            count= 2,
+            memberNo = 1L
         )
 
         coEvery { storeProductService.register(any()) } returns 1L
@@ -96,5 +141,62 @@ internal class ProductRouterTest(private val context: ApplicationContext){
             .bodyValue(request)
             .exchange()
             .expectStatus().isCreated
+            .expectHeader().valueEquals(HttpHeaders.LOCATION, storeProductNo.toString())
+            .expectBody().consumeWith(
+                WebTestClientRestDocumentation.document(
+                    "store-product-register",
+                    ResourceDocumentation.resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(TAG)
+                            .description("상품 상점 등록")
+                            .requestFields(
+                                PayloadDocumentation.fieldWithPath("productName")
+                                    .description("상품명")
+                                    .type(JsonFieldType.STRING),
+                                PayloadDocumentation.fieldWithPath("address")
+                                    .description("상점 주소")
+                                    .type(JsonFieldType.STRING),
+                                PayloadDocumentation.fieldWithPath("price")
+                                    .description("가격")
+                                    .type(JsonFieldType.NUMBER),
+                                PayloadDocumentation.fieldWithPath("parentNo")
+                                    .description("부모 product 번호")
+                                    .type(JsonFieldType.NUMBER),
+                                PayloadDocumentation.fieldWithPath("count")
+                                    .description("개수")
+                                    .type(JsonFieldType.NUMBER),
+                                PayloadDocumentation.fieldWithPath("memberNo")
+                                    .description("회원번호")
+                                    .type(JsonFieldType.NUMBER)
+                            ).build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `상품 전체 조회`(){
+        val productNo = 1L
+        coEvery { productService.getAllProductList() } returns listOf()
+
+        webTestClient.get()
+            .uri("/backend/product/list")
+            .header("Version", "1.0")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().valueEquals(HttpHeaders.LOCATION, productNo.toString())
+            .expectBody().consumeWith(
+                WebTestClientRestDocumentation.document(
+                    "product-all-list",
+                    ResourceDocumentation.resource(
+                        ResourceSnippetParameters.builder()
+                            .tag(TAG)
+                            .description("상품 전체 조회")
+                            .build()
+                    )
+                )
+            )
     }
 }

--- a/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/router/ProductRouterTest.kt
@@ -3,10 +3,11 @@ package com.sp.presentation.router
 import com.ninjasquad.springmockk.*
 import com.sp.application.*
 import com.sp.domain.product.entity.Product
+import com.sp.domain.product.entity.StoreProduct
 import com.sp.presentation.handler.ProductHandler
+import com.sp.presentation.handler.StoreProductHandler
 import com.sp.presentation.request.ProductRegisterRequest
 import io.mockk.coEvery
-import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -22,12 +23,15 @@ import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest
 @ExtendWith(RestDocumentationExtension::class)
-@ContextConfiguration(classes = [ProductRouter::class, ProductHandler::class])
+@ContextConfiguration(classes = [ProductRouter::class, ProductHandler::class, StoreProductHandler::class])
 internal class ProductRouterTest(private val context: ApplicationContext){
     private lateinit var webTestClient: WebTestClient
 
     @MockkBean
     private lateinit var productService: ProductService
+
+    @MockkBean
+    private lateinit var storeProductService: StoreProductService
 
     @BeforeEach
     fun setup(restDocumentation: RestDocumentationContextProvider) {
@@ -37,24 +41,6 @@ internal class ProductRouterTest(private val context: ApplicationContext){
             .filter(WebTestClientRestDocumentation.documentationConfiguration(restDocumentation))
             .build()
     }
-
-    @Test
-    fun `상품 전체 조회`() {
-        val product = Product(
-            name = "꼬북칩",
-            price = 1500
-        )
-        coEvery { productService.findAllProducts() } returns listOf(product)
-        
-        webTestClient.get()
-            .uri("/backend/product")
-            .header("Version", "1.0")
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .accept(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus().isOk
-    }
-
     @Test
     fun `부모 상품 등록`() {
         val request = ProductRegisterRequest(
@@ -72,5 +58,20 @@ internal class ProductRouterTest(private val context: ApplicationContext){
             .bodyValue(request)
             .exchange()
             .expectStatus().isCreated
+    }
+
+    @Test
+    fun `상품명으로 상점 리스트 조회`() {
+        val productName = "koko"
+
+        coEvery { storeProductService.getStoreList(any()) } returns listOf()
+
+        webTestClient.get()
+            .uri("/backend/product/"+productName)
+            .header("Version", "1.0")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isOk
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx512m
+openapi.url=http://localhost
+
+database.url=jdbc:mysql://localhost:3306/sp_mart?serverTimezone=Asia/Seoul&useSSL=false
+database.username=root
+database.password=root1234


### PR DESCRIPTION
- 상품 단일 등록 API
  - presentation -> application ->domain ->core domain data class 만 참조하도록 수정
- 상품 전체 조회 API : transaction 적용
- 상품번호로 상점 리스트 조회 API
  - transaction 적용
  - Repository 하나로 사용 할 수 있도록 CustomizedStoreProductRepository 생성 및 적용
- 상품+상점 등록 API
  - presentation -> application ->domain ->core domain data class 만 참조하도록 수정
  - memberNo 추가

자잘한 기능들 수정하다보니 브랜치로 나누기가 번거로워서 한번에 했어 ㅎㅎ 
569ac6 해당 커밋만 보면 돼!